### PR TITLE
Update 2 - Bugfixes (town colors) & fromcmd

### DIFF
--- a/src/main/java/buttondevteam/chat/ChatProcessing.java
+++ b/src/main/java/buttondevteam/chat/ChatProcessing.java
@@ -221,7 +221,7 @@ public class ChatProcessing {
     }
 
     static String getChannelID(Channel channel, CommandSender sender) {
-        return ("[" + (sender instanceof IDiscordSender ? "§bD§r|" : "") + channel.DisplayName)
+        return ("[" + (sender instanceof IDiscordSender ? "§8D§r|" : "") + channel.DisplayName)
                 + "]";
     }
 

--- a/src/main/java/buttondevteam/chat/PluginMain.java
+++ b/src/main/java/buttondevteam/chat/PluginMain.java
@@ -3,6 +3,7 @@ package buttondevteam.chat;
 import buttondevteam.chat.commands.YeehawCommand;
 import buttondevteam.chat.commands.ucmds.TownColorCommand;
 import buttondevteam.chat.listener.PlayerListener;
+import buttondevteam.chat.listener.TownyListener;
 import buttondevteam.lib.TBMCCoreAPI;
 import buttondevteam.lib.chat.Channel;
 import buttondevteam.lib.chat.Channel.RecipientTestResult;
@@ -80,6 +81,7 @@ public class PluginMain extends JavaPlugin { // Translated to Java: 2015.07.15.
 		Instance = this;
 
 		TBMCCoreAPI.RegisterEventsForExceptions(new PlayerListener(), this);
+		TBMCCoreAPI.RegisterEventsForExceptions(new TownyListener(), this);
 		TBMCChatAPI.AddCommands(this, YeehawCommand.class);
 		Console = this.getServer().getConsoleSender();
 		LoadFiles();
@@ -373,7 +375,7 @@ public class PluginMain extends JavaPlugin { // Translated to Java: 2015.07.15.
 		Resident resident = PluginMain.TU.getResidentMap().get(sender.getName().toLowerCase());
 		RecipientTestResult result = checkTownNationChatInternal(sender, nationchat, resident);
 		if (result.errormessage != null && resident != null && resident.getModes().contains("spy")) // Only use spy if they wouldn't see it
-			result = new RecipientTestResult(1000); // There won't be more than a thousand towns/nations probably
+			result = new RecipientTestResult(1000, "allspies"); // There won't be more than a thousand towns/nations probably
 		return result;
 	}
 
@@ -407,7 +409,7 @@ public class PluginMain extends JavaPlugin { // Translated to Java: 2015.07.15.
 					index = PluginMain.Towns.size() - 1;
 				}
 			}
-			return new RecipientTestResult(index);
+			return new RecipientTestResult(index, nationchat ? nation.getName() : town.getName());
 		} catch (NotRegisteredException e) {
 			return new RecipientTestResult("You (probably) aren't knwon by Towny! (Not in a town)");
 		}

--- a/src/main/java/buttondevteam/chat/commands/appendtext/AppendTextCommandBase.java
+++ b/src/main/java/buttondevteam/chat/commands/appendtext/AppendTextCommandBase.java
@@ -1,8 +1,5 @@
 package buttondevteam.chat.commands.appendtext;
 
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-
 import buttondevteam.chat.ChatPlayer;
 import buttondevteam.chat.listener.PlayerListener;
 import buttondevteam.lib.chat.Channel;
@@ -10,6 +7,8 @@ import buttondevteam.lib.chat.CommandClass;
 import buttondevteam.lib.chat.TBMCChatAPI;
 import buttondevteam.lib.chat.TBMCCommandBase;
 import buttondevteam.lib.player.TBMCPlayer;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 @CommandClass(modOnly = false, excludeFromPath = true)
 public abstract class AppendTextCommandBase extends TBMCCommandBase {
@@ -26,7 +25,7 @@ public abstract class AppendTextCommandBase extends TBMCCommandBase {
 		if (sender instanceof Player)
 			TBMCChatAPI.SendChatMessage(
 					TBMCPlayer.getPlayer(((Player) sender).getUniqueId(), ChatPlayer.class).CurrentChannel, sender,
-					msg);
+					msg, true);
 		else if (sender.isOp())
 			TBMCChatAPI.SendChatMessage(PlayerListener.ConsoleChannel, sender, msg);
 		else

--- a/src/main/java/buttondevteam/chat/commands/ucmds/NColorCommand.java
+++ b/src/main/java/buttondevteam/chat/commands/ucmds/NColorCommand.java
@@ -45,14 +45,14 @@ public class NColorCommand extends UCommandBase {
 		}
 		if (args.length == 0)
 			return false;
-        final String name = ChatColor.stripColor(player.getDisplayName());
-        String arg = name.startsWith("~") ? "~" + args[0] : args[0]; //Add ~ for nicknames
+		final String name = ChatColor.stripColor(player.getDisplayName()).replace("~", ""); //Remove ~
+		String arg = args[0]; //Don't add ~ for nicknames
         if (!arg.replace("|", "").replace(":", "").equalsIgnoreCase(name)) {
 			player.sendMessage("§cThe name you gave doesn't match your name. Make sure to use "
                     + name + "§c with added vertical lines (|) or colons (:).");
 			return true;
 		}
-        String[] nameparts = arg.split("\\|");
+		String[] nameparts = arg.split("[|:]");
 		Color[] towncolors = PluginMain.TownColors.get(town.getName().toLowerCase());
 		if (towncolors == null) {
 			player.sendMessage("§cYour town doesn't have a color set. The town mayor can set it using /u towncolor.");

--- a/src/main/java/buttondevteam/chat/listener/PlayerJoinLeaveListener.java
+++ b/src/main/java/buttondevteam/chat/listener/PlayerJoinLeaveListener.java
@@ -132,6 +132,7 @@ public class PlayerJoinLeaveListener implements Listener {
             int[] ncl = nclar == null ? null : nclar.stream().mapToInt(Integer::intValue).toArray();
             if (ncl != null && (Arrays.stream(ncl).sum() != name.length() || ncl.length != clrs.length))
                 ncl = null; // Reset if name length changed
+            //System.out.println("ncl: "+Arrays.toString(ncl)+" - sum: "+Arrays.stream(ncl).sum()+" - name len: "+name.length());
             for (int i = 0; i < clrs.length; i++)
                 ret.append(coloredNamePart.apply(ncl == null ? len : ncl[i], i));
             return ret.toString();

--- a/src/main/java/buttondevteam/chat/listener/PlayerListener.java
+++ b/src/main/java/buttondevteam/chat/listener/PlayerListener.java
@@ -172,7 +172,7 @@ public class PlayerListener implements Listener {
 		String name = e.getLastToken();
 		for (Entry<String, UUID> nicknamekv : nicknames.entrySet()) {
 			if (nicknamekv.getKey().startsWith(name.toLowerCase()))
-				e.getTabCompletions().add(Bukkit.getPlayer(nicknamekv.getValue()).getName()); //Tabcomplete with the correct case
+                e.getTabCompletions().add(PluginMain.essentials.getUser(Bukkit.getPlayer(nicknamekv.getValue())).getNick(true)); //Tabcomplete with the correct case
 		}
 	}
 
@@ -293,11 +293,14 @@ public class PlayerListener implements Listener {
 
 	@EventHandler
 	public void onNickChange(NickChangeEvent e) {
-		nicknames.inverse().forcePut(e.getAffected().getBase().getUniqueId(), ChatColor.stripColor(e.getValue()).toLowerCase());
-		//PlayerJoinLeaveListener.updatePlayerColors(e.getAffected().getBase()); //Won't fire this event again
+        String nick = e.getValue();
+        if (nick == null)
+            nicknames.inverse().remove(e.getAffected().getBase().getUniqueId());
+        else
+            nicknames.inverse().forcePut(e.getAffected().getBase().getUniqueId(), ChatColor.stripColor(nick).toLowerCase());
 
 		Bukkit.getScheduler().runTaskLater(PluginMain.Instance, () -> {
-			PlayerJoinLeaveListener.updatePlayerColors(e.getAffected().getBase()); //TODO: Doesn't have effect
+            PlayerJoinLeaveListener.updatePlayerColors(e.getAffected().getBase()); //Won't fire this event again
 		}, 1);
 	}
 }

--- a/src/main/java/buttondevteam/chat/listener/TownyListener.java
+++ b/src/main/java/buttondevteam/chat/listener/TownyListener.java
@@ -1,0 +1,48 @@
+package buttondevteam.chat.listener;
+
+import buttondevteam.chat.PluginMain;
+import com.earth2me.essentials.User;
+import com.palmergames.bukkit.towny.event.*;
+import lombok.val;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class TownyListener implements Listener {
+    @EventHandler
+    public void onTownRename(RenameTownEvent event) {
+        val clrs = PluginMain.TownColors.remove(event.getOldName().toLowerCase());
+        if (clrs != null)
+            PluginMain.TownColors.put(event.getTown().getName().toLowerCase(), clrs);
+    }
+
+    @EventHandler //Gets called on town load as well
+    public void onTownJoin(TownAddResidentEvent event) {
+        Player p = Bukkit.getPlayer(event.getResident().getName());
+        if (p != null)
+            PlayerJoinLeaveListener.updatePlayerColors(p);
+    }
+
+    @EventHandler
+    public void onTownLeave(TownRemoveResidentEvent event) {
+        Player p = Bukkit.getPlayer(event.getResident().getName());
+        if (p != null) {
+            User user = PluginMain.essentials.getUser(p);
+            user.setNickname(ChatColor.stripColor(user.getNick(true).replace("~", "")));
+        }
+    }
+
+    @EventHandler
+    public void onTownDelete(DeleteTownEvent event) {
+        PluginMain.TownColors.remove(event.getTownName().toLowerCase());
+    }
+
+    @EventHandler
+    public void onTownCreate(NewTownEvent event) {
+        Player p = Bukkit.getPlayer(event.getTown().getMayor().getName());
+        if (p != null)
+            p.sendMessage("§6Use /u towncolor <color1> [color2] to set a color for the town.");
+    }
+}

--- a/src/test/java/buttondevteam/chat/ChatFormatIT.java
+++ b/src/test/java/buttondevteam/chat/ChatFormatIT.java
@@ -1,15 +1,5 @@
 package buttondevteam.chat;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import org.bukkit.command.CommandSender;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-
 import buttondevteam.chat.ObjectTestRunner.Objects;
 import buttondevteam.chat.commands.ucmds.admin.DebugCommand;
 import buttondevteam.chat.formatting.ChatFormatter;
@@ -20,6 +10,16 @@ import buttondevteam.chat.formatting.TellrawPart;
 import buttondevteam.core.TestPrepare;
 import buttondevteam.lib.chat.Channel;
 import buttondevteam.lib.chat.Color;
+import net.milkbowl.vault.permission.Permission;
+import org.bukkit.command.CommandSender;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(ObjectTestRunner.class)
 public class ChatFormatIT {
@@ -28,6 +28,7 @@ public class ChatFormatIT {
 		TestPrepare.PrepareServer();
 		final CommandSender sender = Mockito.mock(CommandSender.class);
 		DebugCommand.DebugMode = true;
+		PluginMain.permission = Mockito.mock(Permission.class);
 
 		List<Object> list = new ArrayList<Object>();
 


### PR DESCRIPTION
* Discord will post /tableflip and such even if executed from the same Discord channel (fromcmd)
* Changed Discord indicator to dark gray (#78)
* Made town colors update on town join/leave (#79)
* Fixed town color handling and /u ncolor (#75)
* Nickname tab-completion fixed
* Handling town rename/delete for town colors
* Long overdue small test fix
