### PR TITLE
Fixed chat formatting and Discord message hover info in MC

### DIFF
--- a/src/main/java/buttondevteam/chat/ChatProcessing.java
+++ b/src/main/java/buttondevteam/chat/ChatProcessing.java
@@ -47,6 +47,7 @@ public class ChatProcessing {
     private static final Pattern CODE_PATTERN = Pattern.compile("`");
     private static final Pattern MASKED_LINK_PATTERN = Pattern.compile("\\[([^\\[\\]])\\]\\(([^()])\\)");
     private static final Pattern SOMEONE_PATTERN = Pattern.compile("@someone"); //TODO
+    private static final Pattern STRIKETHROUGH_PATTERN = Pattern.compile("~~");
     private static final Color[] RainbowPresserColors = new Color[]{Color.Red, Color.Gold, Color.Yellow, Color.Green,
             Color.Blue, Color.DarkPurple};
     private static boolean pingedconsole = false;
@@ -58,6 +59,8 @@ public class ChatProcessing {
                     .priority(Priority.High).build(),
             ChatFormatter.builder().regex(ITALIC_PATTERN).italic(true).removeCharCount((short) 1).range(true).build(),
             ChatFormatter.builder().regex(UNDERLINED_PATTERN).underlined(true).removeCharCount((short) 1).range(true)
+                    .build(),
+            ChatFormatter.builder().regex(STRIKETHROUGH_PATTERN).strikethrough(true).removeCharCount((short) 2).range(true)
                     .build(),
             ESCAPE_FORMATTER, ChatFormatter.builder().regex(URL_PATTERN).underlined(true).openlink("$1").build(),
             ChatFormatter.builder().regex(NULL_MENTION_PATTERN).color(Color.DarkRed).build(), // Properly added a bug as a feature

--- a/src/main/java/buttondevteam/chat/ChatProcessing.java
+++ b/src/main/java/buttondevteam/chat/ChatProcessing.java
@@ -104,9 +104,11 @@ public class ChatProcessing {
 
         doFunStuff(sender, e, message);
 
-        ChatPlayer mp = null;
+        ChatPlayer mp;
         if (player != null)
             mp = TBMCPlayerBase.getPlayer(player.getUniqueId(), ChatPlayer.class);
+        else //Due to the online player map, getPlayer() can be more efficient than getAs()
+            mp = e.getUser().getAs(ChatPlayer.class); //May be null
 
         Color colormode = channel.color;
         if (mp != null && mp.OtherColorMode != null)

--- a/src/main/java/buttondevteam/chat/ChatProcessing.java
+++ b/src/main/java/buttondevteam/chat/ChatProcessing.java
@@ -128,7 +128,7 @@ public class ChatProcessing {
         pingedconsole = false; // Will set it to true onmatch (static constructor)
         final String channelidentifier = getChannelID(channel, sender);
 
-        TellrawPart json = createTellraw(sender, message, player, mp, channelidentifier);
+        TellrawPart json = createTellraw(sender, message, player, mp, e.getUser(), channelidentifier);
         long combinetime = System.nanoTime();
         ChatFormatter.Combine(formatters, message, json);
         combinetime = System.nanoTime() - combinetime;
@@ -191,8 +191,8 @@ public class ChatProcessing {
         return gson.toJson(json);
     }
 
-    static TellrawPart createTellraw(CommandSender sender, String message, @Nullable Player player, @Nullable ChatPlayer mp,
-                                     final String channelidentifier) {
+    static TellrawPart createTellraw(CommandSender sender, String message, @Nullable Player player,
+                                     @Nullable ChatPlayer mp, @Nullable ChromaGamerBase cg, final String channelidentifier) {
         TellrawPart json = new TellrawPart("");
         if (mp != null && mp.ChatOnly) {
             json.addExtra(new TellrawPart("[C]")
@@ -213,8 +213,8 @@ public class ChatProcessing {
                     .setHoverEvent(TellrawEvent.create(TellrawEvent.HoverAction.SHOW_TEXT, "Gold Patreon supporter")));
         json.addExtra(new TellrawPart(" <"));
         TellrawPart hovertp = new TellrawPart("");
-        if (mp != null)
-            hovertp.addExtra(new TellrawPart(mp.getInfo(ChromaGamerBase.InfoTarget.MCHover)));
+        if (cg != null)
+            hovertp.addExtra(new TellrawPart(cg.getInfo(ChromaGamerBase.InfoTarget.MCHover)));
         json.addExtra(new TellrawPart(getSenderName(sender, player))
                 .setHoverEvent(TellrawEvent.create(TellrawEvent.HoverAction.SHOW_TEXT, hovertp)));
         json.addExtra(new TellrawPart("> "));

--- a/src/main/java/buttondevteam/chat/commands/appendtext/AppendTextCommandBase.java
+++ b/src/main/java/buttondevteam/chat/commands/appendtext/AppendTextCommandBase.java
@@ -2,13 +2,12 @@ package buttondevteam.chat.commands.appendtext;
 
 import buttondevteam.chat.ChatPlayer;
 import buttondevteam.chat.listener.PlayerListener;
-import buttondevteam.lib.chat.Channel;
-import buttondevteam.lib.chat.CommandClass;
-import buttondevteam.lib.chat.TBMCChatAPI;
-import buttondevteam.lib.chat.TBMCCommandBase;
+import buttondevteam.lib.chat.*;
 import buttondevteam.lib.player.TBMCPlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+
+import java.util.UUID;
 
 @CommandClass(modOnly = false, excludeFromPath = true)
 public abstract class AppendTextCommandBase extends TBMCCommandBase {
@@ -22,14 +21,17 @@ public abstract class AppendTextCommandBase extends TBMCCommandBase {
 		String msg = GetAppendedText();
 		for (int i = args.length - 1; i >= 0; i--)
 			msg = args[i] + " " + msg;
+        ChatPlayer cp;
 		if (sender instanceof Player)
-			TBMCChatAPI.SendChatMessage(
-					TBMCPlayer.getPlayer(((Player) sender).getUniqueId(), ChatPlayer.class).CurrentChannel, sender,
-					msg, true);
+            TBMCChatAPI.SendChatMessage(ChatMessage.builder(
+                    (cp = TBMCPlayer.getPlayer(((Player) sender).getUniqueId(), ChatPlayer.class)).CurrentChannel, sender,
+                    cp, msg).fromCommand(true).build());
 		else if (sender.isOp())
-			TBMCChatAPI.SendChatMessage(PlayerListener.ConsoleChannel, sender, msg);
+            TBMCChatAPI.SendChatMessage(ChatMessage.builder(PlayerListener.ConsoleChannel, sender,
+                    (cp = TBMCPlayer.getPlayer(new UUID(0, 0), ChatPlayer.class)), msg).build());
 		else
-			TBMCChatAPI.SendChatMessage(Channel.GlobalChat, sender, msg);
+            TBMCChatAPI.SendChatMessage(ChatMessage.builder(Channel.GlobalChat, sender,
+                    (cp = TBMCPlayer.getPlayer(new UUID(0, 0), ChatPlayer.class)), msg).build()); //TODO
 		return true;
 	}
 }

--- a/src/main/java/buttondevteam/chat/listener/PlayerListener.java
+++ b/src/main/java/buttondevteam/chat/listener/PlayerListener.java
@@ -5,10 +5,7 @@ import buttondevteam.chat.ChatProcessing;
 import buttondevteam.chat.PluginMain;
 import buttondevteam.lib.TBMCChatEvent;
 import buttondevteam.lib.TBMCCoreAPI;
-import buttondevteam.lib.chat.Channel;
-import buttondevteam.lib.chat.ChatChannelRegisterEvent;
-import buttondevteam.lib.chat.ChatRoom;
-import buttondevteam.lib.chat.TBMCChatAPI;
+import buttondevteam.lib.chat.*;
 import buttondevteam.lib.player.ChromaGamerBase.InfoTarget;
 import buttondevteam.lib.player.TBMCPlayer;
 import buttondevteam.lib.player.TBMCPlayerGetInfoEvent;
@@ -59,9 +56,8 @@ public class PlayerListener implements Listener {
 	public void onPlayerChat(AsyncPlayerChatEvent event) {
 		if (event.isCancelled())
 			return;
-		TBMCChatAPI.SendChatMessage(
-				TBMCPlayer.getPlayer(event.getPlayer().getUniqueId(), ChatPlayer.class).CurrentChannel,
-				event.getPlayer(), event.getMessage());
+		ChatPlayer cp = TBMCPlayer.getPlayer(event.getPlayer().getUniqueId(), ChatPlayer.class);
+		TBMCChatAPI.SendChatMessage(ChatMessage.builder(cp.CurrentChannel, event.getPlayer(), cp, event.getMessage()).build());
 		event.setCancelled(true); // The custom event should only be cancelled when muted or similar
 	}
 
@@ -79,7 +75,7 @@ public class PlayerListener implements Listener {
 		if (sender instanceof Player)
 			mp = TBMCPlayer.getPlayer(((Player) sender).getUniqueId(), ChatPlayer.class);
 		else
-			mp = null;
+			mp = TBMCPlayer.getPlayer(new UUID(0, 0), ChatPlayer.class); //Use 0, 0 for console and whatever - TODO: Refactor console stuff
 		String cmd;
 		final BiPredicate<Channel, String> checkchid = (chan, cmd1) -> cmd1.equalsIgnoreCase(chan.ID) || (chan.IDs != null && Arrays.stream(chan.IDs).anyMatch(cmd1::equalsIgnoreCase));
 		if (index == -1) { // Only the command is run
@@ -138,7 +134,7 @@ public class PlayerListener implements Listener {
 			} else
 				for (Channel channel : Channel.getChannels()) {
 					if (checkchid.test(channel, cmd)) { //Apparently method references don't require final variables
-						TBMCChatAPI.SendChatMessage(channel, sender, message.substring(index + 1));
+						TBMCChatAPI.SendChatMessage(ChatMessage.builder(channel, sender, mp, message.substring(index + 1)).build());
 						return true;
 					}
 				}

--- a/src/test/java/buttondevteam/chat/ChatFormatIT.java
+++ b/src/test/java/buttondevteam/chat/ChatFormatIT.java
@@ -66,11 +66,11 @@ public class ChatFormatIT {
 	public void testMessage() {
 		ArrayList<ChatFormatter> cfs = ChatProcessing.addFormatters(Color.White);
 		final String chid = ChatProcessing.getChannelID(Channel.GlobalChat, sender);
-		final TellrawPart tp = ChatProcessing.createTellraw(sender, message, null, null, chid);
+		final TellrawPart tp = ChatProcessing.createTellraw(sender, message, null, null, null, chid);
 		ChatFormatter.Combine(cfs, message, tp);
 		System.out.println("Testing: " + message);
 		// System.out.println(ChatProcessing.toJson(tp));
-		final TellrawPart expectedtp = ChatProcessing.createTellraw(sender, message, null, null, chid);
+		final TellrawPart expectedtp = ChatProcessing.createTellraw(sender, message, null, null, null, chid);
 		// System.out.println("Raw: " + ChatProcessing.toJson(expectedtp));
 		for (TellrawPart extra : extras)
 			expectedtp.addExtra(extra);


### PR DESCRIPTION
* Fixed the info that shows when hovering over the name for a message that was sent from Discord
* F I X E D . F O R M A T T I N G for the chat, everything works, except /shrug
  * Went from 6 failed and 1 passed tests to 1 failed and 6 passed tests (with a few lines of code)
* Added support for strikethrough text

#71